### PR TITLE
Pass JWT using ephemeral input variable instead of temporary file

### DIFF
--- a/deployments.tfdeploy.hcl
+++ b/deployments.tfdeploy.hcl
@@ -7,9 +7,9 @@ identity_token "aws" {
 
 deployment "production" {
   variables = {
-    region              = "us-east-1"
-    role_arn            = "<Set to your AWS IAM OIDC role ARN>"
-    identity_token_file = identity_token.aws.jwt_filename
-    default_tags      = { stacks-preview-example = "lambda-api-gateway-stack" }
+    region         = "us-east-1"
+    role_arn       = "<Set to your AWS IAM OIDC role ARN>"
+    identity_token = identity_token.aws.jwt
+    default_tags   = { stacks-preview-example = "lambda-api-gateway-stack" }
   }
 }

--- a/providers.tfstack.hcl
+++ b/providers.tfstack.hcl
@@ -28,8 +28,8 @@ provider "aws" "this" {
     region = var.region
 
     assume_role_with_web_identity {
-      role_arn                = var.role_arn
-      web_identity_token_file = var.identity_token_file
+      role_arn           = var.role_arn
+      web_identity_token = var.identity_token
     }
 
     default_tags {

--- a/variables.tfstack.hcl
+++ b/variables.tfstack.hcl
@@ -5,8 +5,9 @@ variable "region" {
   type = string
 }
 
-variable "identity_token_file" {
-  type = string
+variable "identity_token" {
+  type      = string
+  ephemeral = true
 }
 
 variable "role_arn" {


### PR DESCRIPTION
Before Terraform Core supported ephemeral input variables we were using a workaround of passing the JWT as a file on disk so that it could vary between plan and apply without causing problems. We no longer need that workaround because Terraform Core can now accept a JWT through any input variable that's declared as accepting ephemeral values.

The HCP Terraform production environment now has a new enough version of the Terraform Cloud Agent available for stacks private preview that this configuration can work, and configuring it in this way avoids writing the JWT to disk at all.
